### PR TITLE
Fail when JSON for cases is not valid

### DIFF
--- a/src/main/java/com/bioraft/rundeck/conditional/SwitchCaseStepPlugin.java
+++ b/src/main/java/com/bioraft/rundeck/conditional/SwitchCaseStepPlugin.java
@@ -27,6 +27,7 @@ import com.dtolabs.rundeck.plugins.descriptions.RenderingOption;
 import com.dtolabs.rundeck.plugins.descriptions.RenderingOptions;
 import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.dtolabs.rundeck.plugins.step.StepPlugin;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.CODE_SYNTAX_MODE;
 import static com.dtolabs.rundeck.core.plugins.configuration.StringRenderingConstants.DISPLAY_TYPE_KEY;
@@ -59,20 +60,23 @@ public class SwitchCaseStepPlugin implements StepPlugin {
 	@PluginProperty(title = "Test Value", description = "Test value", required = true)
 	private String testValue;
 
-	@PluginProperty(title = "Default", description = "Default value", required = false)
+	@PluginProperty(title = "Default", description = "Default value")
 	private String defaultValue;
 
-	@PluginProperty(title = "Make global?", description = "Elevate this variable to global scope (default: false)", required = false)
+	@PluginProperty(title = "Make global?", description = "Elevate this variable to global scope (default: false)")
 	private boolean elevateToGlobal;
 
 	@Override
 	public void executeStep(final PluginStepContext ctx, final Map<String, Object> cfg) throws StepException {
 
-		String group = cfg.getOrDefault("group", this.group).toString();
-		String name = cfg.getOrDefault("name", this.name).toString();
-		String cases = cfg.getOrDefault("cases", this.cases).toString();
-		String testValue = cfg.getOrDefault("testValue", this.testValue).toString();
-		boolean elevateToGlobal = cfg.getOrDefault("elevateToGlobal", this.elevateToGlobal).toString().equals("true");
+		group = cfg.getOrDefault("group", this.group).toString();
+		name = cfg.getOrDefault("name", this.name).toString();
+		cases = cfg.getOrDefault("cases", this.cases).toString();
+		testValue = cfg.getOrDefault("testValue", this.testValue).toString();
+		if (cfg.containsKey("elevateToGlobal")) {
+			elevateToGlobal = cfg.get("elevateToGlobal").equals("true");
+		}
+
 		boolean globalHasDefault = defaultValue != null && defaultValue.length() > 0;
 		boolean cfgHasDefault = cfg.containsKey("defaultValue") && cfg.get("defaultValue") != null;
 		if (cfgHasDefault) {
@@ -82,10 +86,15 @@ public class SwitchCaseStepPlugin implements StepPlugin {
 		ctx.getLogger().log(Constants.DEBUG_LEVEL,
 				"Setting " + group + "." + name + " based on " + testValue + " " + cases);
 
-		if (cfgHasDefault || globalHasDefault) {
-			(new Switch(ctx)).switchCase(group, name, cases, testValue, defaultValue, elevateToGlobal);
-		} else {
-			(new Switch(ctx)).switchCase(group, name, cases, testValue, elevateToGlobal);
+		try {
+			if (cfgHasDefault || globalHasDefault) {
+				(new Switch(ctx)).switchCase(group, name, cases, testValue, defaultValue, elevateToGlobal);
+			} else {
+				(new Switch(ctx)).switchCase(group, name, cases, testValue, elevateToGlobal);
+			}
+		} catch (
+				JsonProcessingException e) {
+			throw new StepException(e.getMessage(), Switch.Causes.InvalidJSON);
 		}
 	}
 

--- a/src/test/java/com/bioraft/rundeck/conditional/SwitchCaseNodeStepPluginTest.java
+++ b/src/test/java/com/bioraft/rundeck/conditional/SwitchCaseNodeStepPluginTest.java
@@ -60,6 +60,10 @@ public class SwitchCaseNodeStepPluginTest {
 
 	@Mock
 	INodeEntry node;
+	private final String group = "raft";
+	private final String name = "test";
+	private final String testValue = "any";
+	private final String defaultValue = "any";
 
 	@Before
 	public void setUp() {
@@ -69,7 +73,7 @@ public class SwitchCaseNodeStepPluginTest {
 	@Test
 	public void runTestOne() throws NodeStepException {
 		Map<String, String> cases = ImmutableMap.<String, String>builder().put("k1", "v1").put("k2", "v2").build();
-		this.runTest("v1", "k1", cases, "any");
+		this.runTest("v1", "k1", cases, defaultValue);
 	}
 
 	@Test
@@ -81,7 +85,7 @@ public class SwitchCaseNodeStepPluginTest {
 	@Test
 	public void returnsDefaultOnNoMatch() throws NodeStepException {
 		Map<String, String> cases = ImmutableMap.<String, String>builder().put("k1", "v1").put("k2", "v2").build();
-		this.runTest("any", "k3", cases, "any");
+		this.runTest(testValue, "k3", cases, defaultValue);
 	}
 
 	@Test
@@ -97,10 +101,32 @@ public class SwitchCaseNodeStepPluginTest {
 		this.runTestNoDefault(configuration);
 	}
 
+	@Test(expected = NodeStepException.class)
+	public void testInvalidCases() throws NodeStepException {
+		StringBuffer caseString = new StringBuffer();
+		Map<String, String> cases = ImmutableMap.<String, String>builder().put("k1", "v1").put("k2", "v2").build();
+		cases.forEach((k, v) -> caseString.append('"').append(k).append('"').append(":").append('"').append(v).append('"').append(","));
+		invalidInput(caseString.toString());
+	}
+
+	private void invalidInput(String caseString)
+			throws NodeStepException {
+
+		Map<String, Object> configuration = new HashMap<>();
+		configuration.put("group", group);
+		configuration.put("name", name);
+		configuration.put("cases", caseString);
+		configuration.put("testValue", testValue);
+		configuration.put("defaultValue", defaultValue);
+
+		when(context.getOutputContext()).thenReturn(sharedOutputContext);
+		when(context.getLogger()).thenReturn(logger);
+
+		this.plugin.executeNodeStep(context, configuration, node);
+	}
+
 	private void runTest(String expected, String testValue, Map<String, String> cases, String defaultValue)
 			throws NodeStepException {
-		String group = "raft";
-		String name = "test";
 		StringBuffer caseString = new StringBuffer();
 		cases.forEach((k, v) -> caseString.append('"').append(k).append('"').append(":").append('"').append(v).append('"').append(","));
 		caseString.setLength(caseString.length() - 1);
@@ -122,8 +148,6 @@ public class SwitchCaseNodeStepPluginTest {
 
 	public void runTestNoDefault(Map<String, Object> configuration)
 			throws NodeStepException {
-		String group = "raft";
-		String name = "test";
 
 		Map<String, String> cases = ImmutableMap.<String, String>builder().put("k1", "v1").put("k2", "v2").build();
 		StringBuilder caseString = new StringBuilder();
@@ -142,5 +166,7 @@ public class SwitchCaseNodeStepPluginTest {
 		verify(context, never()).getOutputContext();
 		verify(sharedOutputContext, never()).addOutput(any(String.class), any(String.class), any(String.class));
 	}
+
+
 
 }


### PR DESCRIPTION
Rather than giving invalid results, Switch/Case construct should throw an exception when the JSON expression used to configure cases is not valid or parseable.